### PR TITLE
Updating hex text input to work with or without a hashtag

### DIFF
--- a/src/components/Verte.vue
+++ b/src/components/Verte.vue
@@ -353,6 +353,10 @@ export default {
     inputChanged (event, value) {
       const el = event.target;
       if (this.currentModel === 'hex') {
+        if (typeof el.value !== 'object' && el.value.indexOf('#') !== 0) {
+          el.value = '#' + el.value;
+        }
+
         this.selectColor(el.value);
         return;
       }


### PR DESCRIPTION
UAT feedback "Missing # in color code will not work"

The color picker is built using a 3rd party plugin, unfortunately that plugin does not support hex values that don't include a starting `#` so I had to update their code to make it work. 

There are multiple places in the code that ensure the hex value contains a starting `#`, so rather than trying to update them all to work with & without a `#` I am simply ensuring that all hex values start with a `#` before doing any processing.

I have submitted a [bug report](https://github.com/baianat/verte/issues/87) and a [pull request](https://github.com/baianat/verte/pull/88) to the original package, but it doesn't look like there have been any changes since the `master` branch was created so I'm not very hopeful that they will pull it in.

So I'm thinking to switch mcms to use our [fixed] forked version, but could be easily convinced that we should just change to a different 3rd party color picker instead.

Fwiw, this plugin was selected by Kristine because it looked and behaved how she wanted. I'm sure we can find another plugin that is pretty similar and doesn't have this `#` issue, but there would probably be a bit more testing involved in switching plugins. 